### PR TITLE
🎉 Feat: 우승팀 예측 화면 와이어프레임 UI 구현

### DIFF
--- a/KickIt/KickIt.xcodeproj/project.pbxproj
+++ b/KickIt/KickIt.xcodeproj/project.pbxproj
@@ -12,6 +12,8 @@
 		E708EB542BF5D5F800AE526C /* DesignWideButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = E708EB532BF5D5F800AE526C /* DesignWideButton.swift */; };
 		E722770C2BF85BB400DE9A7C /* MatchEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = E722770B2BF85BB400DE9A7C /* MatchEvent.swift */; };
 		E722770E2BF87BB500DE9A7C /* TimelineEventRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = E722770D2BF87BB500DE9A7C /* TimelineEventRow.swift */; };
+		E76391772C0377D600B565BE /* DesignHalfButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = E76391762C0377D600B565BE /* DesignHalfButton.swift */; };
+		E78C45852C03263800E5AE40 /* WinningTeamPrediction.swift in Sources */ = {isa = PBXBuildFile; fileRef = E78C45842C03263800E5AE40 /* WinningTeamPrediction.swift */; };
 		E79AFF712BEDC8DC004CAF75 /* KickItApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = E79AFF702BEDC8DC004CAF75 /* KickItApp.swift */; };
 		E79AFF732BEDC8DC004CAF75 /* SplashView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E79AFF722BEDC8DC004CAF75 /* SplashView.swift */; };
 		E79AFF752BEDC8DD004CAF75 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E79AFF742BEDC8DD004CAF75 /* Assets.xcassets */; };
@@ -31,6 +33,7 @@
 		E79EE7602BF8E5A5005CEF80 /* PredictionPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E79EE75F2BF8E5A5005CEF80 /* PredictionPanel.swift */; };
 		E79EE7622BF99BF8005CEF80 /* HeartRateButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = E79EE7612BF99BF8005CEF80 /* HeartRateButton.swift */; };
 		E7BC9FDE2BF779CE00365EFE /* TimelineEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7BC9FDD2BF779CE00365EFE /* TimelineEvent.swift */; };
+		E7D311882C036F8F0070A31D /* VerticalBarChart.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7D311872C036F8F0070A31D /* VerticalBarChart.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -40,6 +43,8 @@
 		E722770B2BF85BB400DE9A7C /* MatchEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MatchEvent.swift; sourceTree = "<group>"; };
 		E722770D2BF87BB500DE9A7C /* TimelineEventRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineEventRow.swift; sourceTree = "<group>"; };
 		E722770F2BF8917900DE9A7C /* KickIt.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = KickIt.entitlements; sourceTree = "<group>"; };
+		E76391762C0377D600B565BE /* DesignHalfButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignHalfButton.swift; sourceTree = "<group>"; };
+		E78C45842C03263800E5AE40 /* WinningTeamPrediction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WinningTeamPrediction.swift; sourceTree = "<group>"; };
 		E79AFF6D2BEDC8DC004CAF75 /* KickIt.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = KickIt.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		E79AFF702BEDC8DC004CAF75 /* KickItApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KickItApp.swift; sourceTree = "<group>"; };
 		E79AFF722BEDC8DC004CAF75 /* SplashView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashView.swift; sourceTree = "<group>"; };
@@ -60,6 +65,7 @@
 		E79EE75F2BF8E5A5005CEF80 /* PredictionPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PredictionPanel.swift; sourceTree = "<group>"; };
 		E79EE7612BF99BF8005CEF80 /* HeartRateButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeartRateButton.swift; sourceTree = "<group>"; };
 		E7BC9FDD2BF779CE00365EFE /* TimelineEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineEvent.swift; sourceTree = "<group>"; };
+		E7D311872C036F8F0070A31D /* VerticalBarChart.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerticalBarChart.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -78,6 +84,7 @@
 			children = (
 				E708EB4F2BF5D54B00AE526C /* ViewController.swift */,
 				E79EE75F2BF8E5A5005CEF80 /* PredictionPanel.swift */,
+				E7D311872C036F8F0070A31D /* VerticalBarChart.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -199,6 +206,7 @@
 				E79EE75D2BF8A073005CEF80 /* SoccerMatchInfo.swift */,
 				E708EB512BF5D56A00AE526C /* HeartRate.swift */,
 				E7BC9FDD2BF779CE00365EFE /* TimelineEvent.swift */,
+				E78C45842C03263800E5AE40 /* WinningTeamPrediction.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -225,6 +233,7 @@
 				E79AFF9A2BEF7982004CAF75 /* DateExtensions.swift */,
 				E79AFFA02BEF8F1B004CAF75 /* LoadableImage.swift */,
 				E708EB532BF5D5F800AE526C /* DesignWideButton.swift */,
+				E76391762C0377D600B565BE /* DesignHalfButton.swift */,
 				E79EE7612BF99BF8005CEF80 /* HeartRateButton.swift */,
 			);
 			path = Helpers;
@@ -313,6 +322,7 @@
 			files = (
 				E7BC9FDE2BF779CE00365EFE /* TimelineEvent.swift in Sources */,
 				E79AFF912BEDDFC2004CAF75 /* SoccerDiary.swift in Sources */,
+				E7D311882C036F8F0070A31D /* VerticalBarChart.swift in Sources */,
 				E79EE75C2BF89FAC005CEF80 /* SoccerTeam.swift in Sources */,
 				E79AFF9B2BEF7982004CAF75 /* DateExtensions.swift in Sources */,
 				E79AFF732BEDC8DC004CAF75 /* SplashView.swift in Sources */,
@@ -327,11 +337,13 @@
 				E722770E2BF87BB500DE9A7C /* TimelineEventRow.swift in Sources */,
 				E722770C2BF85BB400DE9A7C /* MatchEvent.swift in Sources */,
 				E708EB542BF5D5F800AE526C /* DesignWideButton.swift in Sources */,
+				E76391772C0377D600B565BE /* DesignHalfButton.swift in Sources */,
 				E708EB502BF5D54B00AE526C /* ViewController.swift in Sources */,
 				E79AFF9D2BEF8A86004CAF75 /* SoccerMatchRow.swift in Sources */,
 				E79AFFA12BEF8F1B004CAF75 /* LoadableImage.swift in Sources */,
 				E79AFF942BEE0934004CAF75 /* CustomDatePicker.swift in Sources */,
 				E79EE75E2BF8A073005CEF80 /* SoccerMatchInfo.swift in Sources */,
+				E78C45852C03263800E5AE40 /* WinningTeamPrediction.swift in Sources */,
 				E79AFF812BEDDCBD004CAF75 /* ContentView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/KickIt/KickIt/Global/Helpers/DesignHalfButton.swift
+++ b/KickIt/KickIt/Global/Helpers/DesignHalfButton.swift
@@ -1,0 +1,49 @@
+//
+//  DesignHalfButton.swift
+//  KickIt
+//
+//  Created by 이윤지 on 5/26/24.
+//
+
+import SwiftUI
+
+/// 절반 사이즈의 버튼 뷰
+struct DesignHalfButton: View {
+    /// 버튼 안의 텍스트
+    var label: String
+        
+    /// 버튼 안의 텍스트 색상
+    var labelColor: Color
+    
+    /// 버튼 배경 색상
+    var btnBGColor: Color
+    
+    /// 우측 이모지
+    var img: String?
+    
+    var body: some View {
+        HStack(alignment: .center, spacing: 0) {
+            Text("\(label)")
+                .font(.system(size: 16, weight: .semibold))
+                .foregroundStyle(labelColor)
+            
+            // 우측 이미지가 있다면 배치하기
+            if img != nil {
+                Image(systemName: img!)
+                    .font(.system(size: 16, weight: .semibold))
+                    .foregroundStyle(labelColor)
+                    .padding(.leading, 8)
+            }
+        }
+        .padding([.top, .bottom], 16)
+        .frame(maxWidth: .infinity)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill(btnBGColor)
+        )
+    }
+}
+
+#Preview {
+    DesignHalfButton(label: "다음 예측하기", labelColor: .white, btnBGColor: .gray600, img: "arrow.right")
+}

--- a/KickIt/KickIt/Screen/MatchCalendar/Helpers/PredictionPanel.swift
+++ b/KickIt/KickIt/Screen/MatchCalendar/Helpers/PredictionPanel.swift
@@ -18,6 +18,9 @@ struct PredictionPanel: View {
     /// 드래그 위치 값
     @State private var dragOffset: CGFloat = 0
     
+    /// 예측하기 버튼 클릭 이벤트
+    var onPredictClick: () -> Void
+    
     var body: some View {
         GeometryReader { geometry in
             ZStack(alignment: .bottom) {
@@ -64,6 +67,9 @@ struct PredictionPanel: View {
                         
                         // MARK: - 참여하기 버튼
                         DesignWideButton(label: "참여하기", labelColor: .white, btnBGColor: .gray600)
+                            .onTapGesture {
+                                onPredictClick()
+                            }
                     }
                     .padding(.top, 45)
                     .padding(.bottom, 47)
@@ -114,5 +120,7 @@ struct PredictionPanel: View {
 }
 
 #Preview {
-    PredictionPanel(offsetY: .constant(0))
+    PredictionPanel(offsetY: .constant(0)) {
+        print("예측하기 버튼 클릭")
+    }
 }

--- a/KickIt/KickIt/Screen/MatchCalendar/Helpers/VerticalBarChart.swift
+++ b/KickIt/KickIt/Screen/MatchCalendar/Helpers/VerticalBarChart.swift
@@ -1,0 +1,56 @@
+//
+//  VerticalBarChart.swift
+//  KickIt
+//
+//  Created by 이윤지 on 5/26/24.
+//
+
+import SwiftUI
+
+/// 우승팀 예측하기 가로 막대 그래프
+struct VerticalBarChart: View {
+    /// 막대 그래프에 들어갈 데이터
+    let data: [(String, Double)]
+    
+    var body: some View {
+        // 가장 높은 퍼센트 값을 가진 데이터 찾기
+        let highPercentData = data.max(by: { $0.1 < $1.1 })?.1 ?? 0
+        
+        VStack(alignment: .leading, spacing: 8) {
+            ForEach(data, id: \.0) { chart in
+                ZStack(alignment: .leading) {
+                    // MARK: 막대그래프 배경
+                    RoundedRectangle(cornerRadius: 8)
+                        .fill(.gray50)
+                        .frame(maxWidth: .infinity, maxHeight: 51)
+                    
+                    // MARK: 투표율 막대그래프
+                    RoundedRectangle(cornerRadius: 8)
+                        .fill(chart.1 == highPercentData ? .gray600 : .gray400)
+                        .frame(width: CGFloat(chart.1) * 3, height: 51)
+                    
+                    // MARK: 그래프 이름
+                    Text(chart.0)
+                        .font(.system(size: 16, weight: .medium))
+                        .foregroundStyle(Int(chart.1) > 5 ? .white : .gray600)
+                        .padding(.leading, 20)
+                    
+                    // MARK: 퍼센트 정보
+                    Text("\(Int(chart.1))%")
+                        .font(.system(size: 16, weight: .medium))
+                        .foregroundStyle(Int(chart.1) > 95 ? .white : .gray600)
+                        .padding(.trailing, 20)
+                        .frame(maxWidth: .infinity, alignment: .trailing)
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    VerticalBarChart(data: [
+        (soccerMatch.homeTeam.teamName, 30.0),
+        (soccerMatch.awayTeam.teamName, 65.0),
+        ("무승부", 5.0)
+    ])
+}

--- a/KickIt/KickIt/Screen/MatchCalendar/Views/SoccerMatchInfo.swift
+++ b/KickIt/KickIt/Screen/MatchCalendar/Views/SoccerMatchInfo.swift
@@ -7,12 +7,16 @@
 
 import SwiftUI
 
+/// 1개의 축구 경기 정보 화면
 struct SoccerMatchInfo: View {
     /// 축구 경기 객체
     var soccerMatch: SoccerMatch
     
     /// 예측하기 패널의 높이 값
     @State var offsetY: CGFloat = 0
+    
+    /// 예측하기 버튼 클릭 상태 여부
+    @State private var isPredicted = false
     
     var body: some View {
         ZStack(alignment: .top) {
@@ -173,8 +177,13 @@ struct SoccerMatchInfo: View {
                 .frame(maxHeight: offsetY - 16, alignment: .bottom)
             
             // MARK: - 예측하기 패널
-            PredictionPanel(offsetY: $offsetY)
-                .frame(alignment: .bottom)
+            PredictionPanel(offsetY: $offsetY) {
+                isPredicted = true
+            }
+            .frame(alignment: .bottom)
+        }
+        .navigationDestination(isPresented: $isPredicted) {
+            WinningTeamPrediction(soccerMatch: soccerMatch)
         }
         .ignoresSafeArea(edges: .bottom)
         // 툴 바, 상태 바 색상 변경

--- a/KickIt/KickIt/Screen/MatchCalendar/Views/WinningTeamPrediction.swift
+++ b/KickIt/KickIt/Screen/MatchCalendar/Views/WinningTeamPrediction.swift
@@ -1,0 +1,272 @@
+//
+//  WinningTeamPrediction.swift
+//  KickIt
+//
+//  Created by 이윤지 on 5/26/24.
+//
+
+import Charts
+import SwiftUI
+
+/// 우승팀 예측 화면
+struct WinningTeamPrediction: View {
+    /// 축구 경기 객체
+    var soccerMatch: SoccerMatch
+    
+    /// 뒤로가기 버튼을 위한 변수
+    @Environment(\.presentationMode) var presentationMode: Binding<PresentationMode>
+        
+    /// 클릭 이벤트 변수
+    @State private var clickHomeTeam = false
+    
+    /// 무승부 클릭 변수
+    @State private var clickDraw = false
+    
+    /// 원정팀 클릭 변수
+    @State private var clickAwayTeam = false
+    
+    var body: some View {
+        ZStack {
+            Color(.gray50)
+            VStack(alignment: .leading, spacing: 0) {
+                HStack(spacing: 8) {
+                    Spacer()
+                    
+                    Image(systemName: "soccerball")
+                        .font(.system(size: 24))
+                        .foregroundStyle(.gray600)
+                    
+                    Image(systemName: "soccerball")
+                        .font(.system(size: 24))
+                        .foregroundStyle(.gray400)
+                    
+                    Image(systemName: "soccerball")
+                        .font(.system(size: 24))
+                        .foregroundStyle(.gray400)
+                    
+                    Spacer()
+                }
+                .padding(.top, 60)
+                
+                // 예측을 한 경우
+                if clickHomeTeam || clickAwayTeam || clickDraw {
+                    Text("승리 팀 예측 완료!")
+                        .font(.system(size: 24, weight: .semibold))
+                        .foregroundStyle(.gray600)
+                        .padding(.top, 56)
+                        .frame(maxWidth: .infinity, alignment: .center)
+                }
+                // 예측을 안 한 경우
+                else {
+                    Text("우승 팀 예측하기")
+                        .font(.system(size: 14, weight: .medium))
+                        .foregroundStyle(.black)
+                        .padding(.top, 56)
+                        .padding(.leading, 30)
+                    
+                    Text("이번 경기에서 어느 팀이 승리할까요?")
+                        .font(.system(size: 18, weight: .semibold))
+                        .foregroundStyle(.black)
+                        .padding(.top, 10)
+                        .padding(.leading, 30)
+                }
+                
+                // 예측한 우승 팀 정보
+                VStack(alignment: .center, spacing: 8) {
+                    Text("나의 선택")
+                        .font(.system(size: 14, weight: .medium))
+                        .foregroundStyle(.gray600)
+                    
+                    // 홈 팀을 선택한 경우
+                    if clickHomeTeam {
+                        LoadableImage(image: soccerMatch.homeTeam.teamImgURL)
+                            .frame(width: 120, height: 120)
+                            .background(.white)
+                            .clipShape(Circle())
+                        
+                        Text(soccerMatch.homeTeam.teamName)
+                            .font(.system(size: 16, weight: .medium))
+                            .foregroundStyle(.gray600)
+                    }
+                    // 원정팀을 선택한 경우
+                    else if clickAwayTeam {
+                        LoadableImage(image: soccerMatch.awayTeam.teamImgURL)
+                            .frame(width: 120, height: 120)
+                            .background(.white)
+                            .clipShape(Circle())
+                        
+                        Text(soccerMatch.awayTeam.teamName)
+                            .font(.system(size: 16, weight: .medium))
+                            .foregroundStyle(.gray600)
+                    }
+                    // 무승부를 선택한 경우
+                    else if clickDraw {
+                        Circle()
+                            .frame(width: 120, height: 120)
+                            .foregroundStyle(.gray100)
+                        
+                        Text("무승부")
+                            .font(.system(size: 16, weight: .medium))
+                            .foregroundStyle(.gray600)
+                    }
+                    // 미선택한 경우
+                    else {
+                        Circle()
+                            .frame(width: 120, height: 120)
+                            .foregroundStyle(.gray100)
+                        
+                        Text("선택해주세요")
+                            .font(.system(size: 16, weight: .medium))
+                            .foregroundStyle(.gray600)
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .center)
+                .padding(.top, 67)
+                
+                // 예측을 한 경우
+                if clickHomeTeam || clickAwayTeam || clickDraw {
+                    // 예측 결과 띄우기
+                    VStack(alignment: .leading, spacing: 0) {
+                        Text("예측 결과")
+                            .font(.system(size: 16, weight: .semibold))
+                            .foregroundStyle(.gray600)
+                        
+                        // MARK: - 예측 결과 가로 막대 그래프
+                        VerticalBarChart(data: [
+                            (soccerMatch.homeTeam.teamName, 30.0),
+                            (soccerMatch.awayTeam.teamName, 65.0),
+                            ("무승부", 5.0)
+                        ])
+                        .padding(.top, 20)
+                    }
+                    .padding([.top, .bottom], 32)
+                    .padding([.leading, .trailing], 20)
+                    .background(
+                        RoundedRectangle(cornerRadius: 8)
+                            .fill(.white)
+                    )
+                    .padding([.leading, .trailing], 16)
+                    .padding(.top, 34)
+                }
+                // 예측을 안 한 경우
+                else {
+                    // 선택지 보여주기
+                    HStack(alignment: .center, spacing: 10) {
+                        // MARK: 홈 팀
+                        Button {
+                            clickHomeTeam.toggle()
+                            clickAwayTeam = false
+                            clickDraw = false
+                        } label: {
+                            VStack(alignment: .center, spacing: 20) {
+                                LoadableImage(image: soccerMatch.homeTeam.teamImgURL)
+                                    .frame(width: 60, height: 60)
+                                    .background(.white)
+                                    .clipShape(Circle())
+                                
+                                Text(soccerMatch.homeTeam.teamName)
+                                    .font(.system(size: 16, weight: .bold))
+                                    .foregroundStyle(.gray600)
+                            }
+                            .padding(24)
+                            .background(
+                                RoundedRectangle(cornerRadius: 8)
+                                    .fill(.white)
+                                    .stroke(.gray100, style: StrokeStyle(lineWidth: 1))
+                            )
+                        }
+                        
+                        // MARK: 무승부
+                        Button {
+                            clickHomeTeam = false
+                            clickAwayTeam = false
+                            clickDraw.toggle()
+                        } label: {
+                            VStack(alignment: .center, spacing: 20) {
+                                Circle()
+                                    .fill(.clear)
+                                    .frame(width: 60, height: 60)
+                                
+                                Text("무승부")
+                                    .font(.system(size: 16, weight: .medium))
+                                    .foregroundStyle(.gray600)
+                            }
+                            .padding(24)
+                            .background(
+                                RoundedRectangle(cornerRadius: 8)
+                                    .fill(.white)
+                                    .stroke(.gray100, style: StrokeStyle(lineWidth: 1))
+                            )
+                        }
+                        
+                        // MARK: 원정 팀
+                        Button {
+                            clickHomeTeam = false
+                            clickAwayTeam.toggle()
+                            clickDraw = false
+                        } label: {
+                            VStack(alignment: .center, spacing: 20) {
+                                LoadableImage(image: soccerMatch.awayTeam.teamImgURL)
+                                    .frame(width: 60, height: 60)
+                                    .background(.white)
+                                    .clipShape(Circle())
+                                
+                                Text(soccerMatch.awayTeam.teamName)
+                                    .font(.system(size: 16, weight: .bold))
+                                    .foregroundStyle(.gray600)
+                            }
+                            .padding(24)
+                            .background(
+                                RoundedRectangle(cornerRadius: 8)
+                                    .fill(.white)
+                                    .stroke(.gray100, style: StrokeStyle(lineWidth: 1))
+                            )
+                        }
+                    }
+                    .frame(maxWidth: .infinity)
+                    .padding(.top, 46)
+                }
+                
+                Spacer()
+                
+                // 예측을 한 경우
+                if clickHomeTeam || clickAwayTeam || clickDraw {
+                    HStack(spacing: 8) {
+                        // 왼쪽 여백을 위한 네모
+                        Rectangle()
+                            .opacity(0)
+                        
+                        // MARK: - 다음 예측하기 버튼
+                        DesignHalfButton(label: "다음 예측하기", labelColor: Color.white, btnBGColor: Color.gray600, img: "arrow.right")
+                    }
+                    .padding([.leading, .trailing], 16)
+                }
+                // 예측을 안 한 경우
+                else {
+                    // MARK: - 예측하기 버튼
+                    DesignWideButton(label: "예측하기", labelColor: Color.gray400, btnBGColor: Color.gray100)
+                }
+            }
+        }
+        .ignoresSafeArea(edges: .top)
+        .navigationBarBackButtonHidden(true)
+        .toolbar {
+            ToolbarItem(placement: .topBarLeading) {
+                Button {
+                    // 뒤로가기
+                    self.presentationMode.wrappedValue.dismiss()
+                } label: {
+                    // MARK: - 우승팀 예측 화면 닫기
+                    Image(systemName: "xmark")
+                        .foregroundStyle(.gray400)
+                        .padding(.leading, 16)
+                }
+            }
+        }
+        .toolbar(.hidden, for: .tabBar) // 네비게이션 숨기기
+    }
+}
+
+#Preview {
+    WinningTeamPrediction(soccerMatch: soccerMatches[0])
+}


### PR DESCRIPTION
## 🎟️ 관련 이슈 번호, Jira 번호
closed issue #13
closed jira #SF-47

## ✨ 변경 사항
- 우승팀 예측하기 화면 UI 구현
- 우승팀 예측하기 버튼 클릭 이벤트 구현
- 우승팀 예측 완료 화면 구현
- 예측 결과 그래프
- DesignHalfButton 파일 추가 ➡️ 텍스트, 이모지가 함께 있는 디자인 버튼
> Global > Helpers 폴더에 넣어두었어요