### PR TITLE
🔧 [FIX] 경기캘린더 화면 내 API 모두 이전 API응답 모델로 변경

### DIFF
--- a/KickIt/KickIt/Network/APIEssentials/CommonResponse.swift
+++ b/KickIt/KickIt/Network/APIEssentials/CommonResponse.swift
@@ -10,13 +10,13 @@ import Foundation
 /// 공통 API 응답 모델
 struct CommonResponse<T: Codable>: Codable {
     var status: Int
-    var success: Bool
+    var isSuccess: Bool
     var message: String
     var data: T?
     
     enum CodingKeys: String, CodingKey {
         case status = "status"
-        case success = "success"
+        case isSuccess = "isSuccess"
         case message = "message"
         case data = "data"
     }
@@ -24,7 +24,7 @@ struct CommonResponse<T: Codable>: Codable {
     init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: CodingKeys.self)
         status = (try? values.decode(Int.self, forKey: .status)) ?? -1
-        success = (try? values.decode(Bool.self, forKey: .success)) ?? false
+        isSuccess = (try? values.decode(Bool.self, forKey: .isSuccess)) ?? false
         message = (try? values.decode(String.self, forKey: .message)) ?? ""
         data = (try? values.decode(T.self, forKey: .data)) ?? nil
     }

--- a/KickIt/KickIt/Network/APIManagers/HeartRateAPI.swift
+++ b/KickIt/KickIt/Network/APIManagers/HeartRateAPI.swift
@@ -33,20 +33,19 @@ class HeartRateAPI: BaseAPI {
                     switch response.result {
                     // API 호출 성공
                     case .success(let result):
-                        // 응답 성공
-                        if result.success {
-                            promise(.success(result.data!))
-                        } else {
-                            switch result.status {
-                            case 401: // TODO: 토큰 오류 interceptor 코드 작동하는지 확인 후, 삭제해도 OK
-                                return promise(.failure(.authFailed))
-                            case 400..<500: // 요청 실패
-                                return promise(.failure(.requestErr(result.message)))
-                            case 500: // 서버 오류
-                                return promise(.failure(.serverErr(result.message)))
-                            default: // 알 수 없는 오류
-                                return promise(.failure(.unknown(result.message)))
-                            }
+                        // FIXME: 백엔드에서 isSuccess값 보내주면, 이에 맞춰 로직 변경하기!
+                        // 이거는 내가 어떻게 바꾸는지 알려줄게!!
+                        switch result.status {
+                        case 200:
+                            return promise(.success(result.data!))
+                        case 401: // TODO: 토큰 오류 interceptor 코드 작동하는지 확인 후, 삭제해도 OK
+                            return promise(.failure(.authFailed))
+                        case 400..<500: // 요청 실패
+                            return promise(.failure(.requestErr(result.message)))
+                        case 500: // 서버 오류
+                            return promise(.failure(.serverErr(result.message)))
+                        default: // 알 수 없는 오류
+                            return promise(.failure(.unknown(result.message)))
                         }
                     // API 호출 실패
                     case .failure(let error):

--- a/KickIt/KickIt/Network/APIManagers/MatchCalendarAPI.swift
+++ b/KickIt/KickIt/Network/APIManagers/MatchCalendarAPI.swift
@@ -19,8 +19,9 @@ class MatchCalendarAPI: BaseAPI {
     }
     
     /// 한달 경기 일정 조회 API
-    func getYearMonthSoccerMatches(request: SoccerMatchMonthlyRequest) -> AnyPublisher<SoccerMatchMonthlyResponse, NetworkError> {
-        return Future<SoccerMatchMonthlyResponse, NetworkError> { [weak self] promise in
+    // FIXME: [SoccerMatchMonthlyResponse] -> SoccerMatchMonthlyResponse로 수정하기
+    func getYearMonthSoccerMatches(request: SoccerMatchMonthlyRequest) -> AnyPublisher<[SoccerMatchMonthlyResponse], NetworkError> {
+        return Future<[SoccerMatchMonthlyResponse], NetworkError> { [weak self] promise in
             guard let self = self else {
                 // 잘못된 요청
                 promise(.failure(.pathErr))
@@ -29,24 +30,22 @@ class MatchCalendarAPI: BaseAPI {
             
             self.AFManager.request(MatchCalendarService.getYearMonthSoccerMatches(request), interceptor: MyRequestInterceptor())
                 .validate()
-                .responseDecodable(of: CommonResponse<SoccerMatchMonthlyResponse>.self) { response in
+                .responseDecodable(of: CommonResponse<[SoccerMatchMonthlyResponse]>.self) { response in
                     switch response.result {
                     // API 호출 성공
                     case .success(let result):
-                        // 응답 성공
-                        if result.success {
-                            promise(.success(result.data ?? SoccerMatchMonthlyResponse(soccerSeason: "", matchDates: [], soccerTeamNames: [])))
-                        } else {
-                            switch result.status {
-                            case 401: // TODO: 토큰 오류 interceptor 코드 작동하는지 확인 후, 삭제해도 OK
-                                return promise(.failure(.authFailed))
-                            case 400..<500: // 요청 실패
-                                return promise(.failure(.requestErr(result.message)))
-                            case 500: // 서버 오류
-                                return promise(.failure(.serverErr(result.message)))
-                            default: // 알 수 없는 오류
-                                return promise(.failure(.unknown(result.message)))
-                            }
+                        // FIXME: isSuccess 활용하여 로직 수정 필요
+                        switch result.status {
+                        case 200:
+                            return promise(.success(result.data ?? [SoccerMatchMonthlyResponse(matchDates: "")]))
+                        case 401: // TODO: 토큰 오류 interceptor 코드 작동하는지 확인 후, 삭제해도 OK
+                            return promise(.failure(.authFailed))
+                        case 400..<500: // 요청 실패
+                            return promise(.failure(.requestErr(result.message)))
+                        case 500: // 서버 오류
+                            return promise(.failure(.serverErr(result.message)))
+                        default: // 알 수 없는 오류
+                            return promise(.failure(.unknown(result.message)))
                         }
                     // API 호출 실패
                     case .failure(let error):
@@ -71,21 +70,18 @@ class MatchCalendarAPI: BaseAPI {
                     switch response.result {
                     // API 호출 성공
                     case .success(let result):
-                        // 응답 성공
-                        if result.success {
-                            promise(.success(result.data ?? []))
-                        }
-                        else {
-                            switch result.status {
-                            case 401: // TODO: 토큰 오류 interceptor 코드 작동하는지 확인 후, 삭제해도 OK
-                                return promise(.failure(.authFailed))
-                            case 400..<500: // 요청 실패
-                                return promise(.failure(.requestErr(result.message)))
-                            case 500: // 서버 오류
-                                return promise(.failure(.serverErr(result.message)))
-                            default: // 알 수 없는 오류
-                                return promise(.failure(.unknown(result.message)))
-                            }
+                        // FIXME: isSuccess 활용하여 로직 수정 필요
+                        switch result.status {
+                        case 200:
+                            return promise(.success(result.data ?? []))
+                        case 401: // TODO: 토큰 오류 interceptor 코드 작동하는지 확인 후, 삭제해도 OK
+                            return promise(.failure(.authFailed))
+                        case 400..<500: // 요청 실패
+                            return promise(.failure(.requestErr(result.message)))
+                        case 500: // 서버 오류
+                            return promise(.failure(.serverErr(result.message)))
+                        default: // 알 수 없는 오류
+                            return promise(.failure(.unknown(result.message)))
                         }
                     // API 호출 실패
                     case .failure(let error):

--- a/KickIt/KickIt/Network/APIManagers/UserAPI.swift
+++ b/KickIt/KickIt/Network/APIManagers/UserAPI.swift
@@ -65,7 +65,7 @@ class UserAPI: BaseAPI {
                     switch response.result {
                     case .success(let result):
                         // API 호출 성공
-                        if result.success {
+                        if result.isSuccess {
                             // 응답 성공
                             promise(.success(result))
                         } else {

--- a/KickIt/KickIt/Network/Bases/TargetType.swift
+++ b/KickIt/KickIt/Network/Bases/TargetType.swift
@@ -55,7 +55,7 @@ extension TargetType {
     /// URL 요청 생성
     func asURLRequest() throws -> URLRequest {
         // ?를 인코딩할 수 있는 형태로 변경
-        let url = try (baseURL + endPoint).encodeURL()?.asURL()
+        let url = try baseURL.encodeURL()?.asURL()
         var urlRequest = try URLRequest(url: url!, method: method)
         
         // header 설정

--- a/KickIt/KickIt/Network/Models/Response/SoccerMatchDailyResponse.swift
+++ b/KickIt/KickIt/Network/Models/Response/SoccerMatchDailyResponse.swift
@@ -13,8 +13,8 @@ struct SoccerMatchDailyResponse: Codable {
     let soccerSeason: String // 축구 경기 시즌
     var matchDate: String // 축구 경기 날짜
     var matchTime: String // 축구 경기 시간
-    var homeTeamEmblemURL: String // 홈팀 엠블럼
-    var awayTeamEmblemURL: String // 원정팀 엠블럼
+    //var homeTeamEmblemURL: String // 홈팀 엠블럼
+    //var awayTeamEmblemURL: String // 원정팀 엠블럼
     var homeTeamName: String // 홈팀 이름
     var awayTeamName: String // 원정팀 이름
     var homeTeamScore: Int? // 홈팀 스코어
@@ -32,6 +32,7 @@ struct SoccerMatchDailyResponse: Codable {
         case matchRound = "round"
         case matchCode = "status"
         case awayTeamScore = "awayteamScore"
-        case id, homeTeamEmblemURL, awayTeamEmblemURL, homeTeamScore, stadium
+        case id, homeTeamScore, stadium
+        //case homeTeamEmblemURL, awayTeamEmblemURL,
     }
 }

--- a/KickIt/KickIt/Network/Models/Response/SoccerMatchMonthlyResponse.swift
+++ b/KickIt/KickIt/Network/Models/Response/SoccerMatchMonthlyResponse.swift
@@ -9,13 +9,14 @@ import Foundation
 
 /// 한달 경기 일정 조회 Response 모델
 struct SoccerMatchMonthlyResponse: Codable {
-    let soccerSeason: String // 축구 시즌
-    let matchDates: Array<String> // 축구 경기 날짜
-    let soccerTeamNames: Array<String> // 팀 이름
+    let matchDates: String // 축구 경기 날짜
+    //let soccerSeason: String // 축구 시즌
+    //let matchDates: [String] // 축구 경기 날짜
+    //let soccerTeamNames: Array<String> // 팀 이름
     
     enum CodingKeys: String, CodingKey {
-        case soccerSeason = "soccerSeason"
+        //case soccerSeason = "soccerSeason"
         case matchDates = "date"
-        case soccerTeamNames = "teamNames"
+        //case soccerTeamNames = "teamNames"
     }
 }

--- a/KickIt/KickIt/Screen/Home/Views/Home.swift
+++ b/KickIt/KickIt/Screen/Home/Views/Home.swift
@@ -90,7 +90,7 @@ struct btnCard1: View {
         ZStack{
             RoundedRectangle(cornerRadius: 8)
                 .frame(width: 165, height: 196)
-                .foregroundStyle(LinearGradient.limeGradient)
+                .foregroundStyle(LinearGradient.greenGradient)
             VStack(alignment: .center, spacing: 4){
                 VStack(alignment: .leading, spacing: 0){
                     VStack(alignment: .leading, spacing: 0){

--- a/KickIt/KickIt/Screen/MatchCalendar/ViewModels/MatchCalendarViewModel.swift
+++ b/KickIt/KickIt/Screen/MatchCalendar/ViewModels/MatchCalendarViewModel.swift
@@ -23,11 +23,13 @@ final class MatchCalendarViewModel: MatchCalendarViewModelProtocol {
         MatchCalendarAPI.shared.getYearMonthSoccerMatches(request: request)
             // DTO -> Entity로 변경
             .map { responseDTO in
-                let dates = responseDTO.matchDates.compactMap { stringToDate2(date: $0) }
-                let teamNames = responseDTO.soccerTeamNames
-                let season = responseDTO.soccerSeason
+                // FIXME: dates, teamNames, season가 있는 버전으로 바꾸기. -> 주석 삭제!
+                let dates = responseDTO.compactMap { stringToDate2(date: $0.matchDates) }
+                //let dates = responseDTO.matchDates.compactMap { stringToDate2(date: $0) }
+                //let teamNames = responseDTO.soccerTeamNames
+                //let season = responseDTO.soccerSeason
                 
-                return (dates, teamNames, season)
+                return (dates)
             }
             // 메인 스레드에서 데이터 처리
             .receive(on: DispatchQueue.main)
@@ -41,15 +43,16 @@ final class MatchCalendarViewModel: MatchCalendarViewModelProtocol {
                 }
             },
             // monthlyMatches에 publisher 응답 결과 업데이트
-            receiveValue: { [weak self] (dates, teams, season) in
+            receiveValue: { [weak self] (dates) in
                 self?.matchDates = dates
-                self?.soccerTeamNames = ["전체"] + teams
-                self?.soccerSeason = season
+                //self?.soccerTeamNames = ["전체"] + teams
+                //self?.soccerSeason = season
             })
             .store(in: &cancellables)
     }
     
     /// 하루 경기 일정 조회
+    // FIXME: 홈팀, 원정팀 엠블럼 데이터 받아올 수 있게 되면, 추가하기!
     func getDailySoccerMatches(request: SoccerMatchDailyRequest) {
         MatchCalendarAPI.shared.getDailySoccerMatches(request: request)
             // DTO -> Entity로 변경
@@ -62,8 +65,8 @@ final class MatchCalendarViewModel: MatchCalendarViewModelProtocol {
                         matchTime: stringToTime(time: data.matchTime),
                         stadium: data.stadium,
                         matchRound: data.matchRound,
-                        homeTeam: SoccerTeam(teamEmblemURL: data.homeTeamEmblemURL, teamName: data.homeTeamName),
-                        awayTeam: SoccerTeam(teamEmblemURL: data.awayTeamEmblemURL, teamName: data.awayTeamName),
+                        homeTeam: SoccerTeam(teamEmblemURL: "", teamName: data.homeTeamName),
+                        awayTeam: SoccerTeam(teamEmblemURL: "", teamName: data.awayTeamName),
                         matchCode: data.matchCode)
                 }
             }

--- a/KickIt/KickIt/Screen/MatchCalendar/Views/MatchCalendar.swift
+++ b/KickIt/KickIt/Screen/MatchCalendar/Views/MatchCalendar.swift
@@ -143,6 +143,14 @@ struct MatchCalendar: View {
                     teamName: selectedTeamName
                 )
             )
+            
+            // 하루 경기 일정 조회 API 연결
+            getDailySoccerMatches(
+                request: SoccerMatchDailyRequest(
+                    date: dateToString4(date: currentDate),
+                    teamName: selectedTeamName
+                )
+            )
         })
         .tint(.gray200)
         .navigationBarBackButtonHidden()
@@ -208,7 +216,7 @@ struct MatchCalendar: View {
                     .foregroundStyle(.gray500)
                     .padding(.top, 52)
                 
-                    // FIXME: api 연결 시, 더미 데이터 삭제하기
+                    // FIXME: api 연결 시, 아래 코드 삭제하기
                     ForEach(dummySoccerMatches) { match in
                         SoccerMatchRow(soccerMatch: match)
                             .padding(.horizontal, 16)

--- a/KickIt/KickIt/Screen/MatchCalendar/Views/SoccerMatchInfo.swift
+++ b/KickIt/KickIt/Screen/MatchCalendar/Views/SoccerMatchInfo.swift
@@ -279,7 +279,7 @@ struct SoccerMatchInfo: View {
                                         .padding(12)
                                         .background(
                                             RoundedRectangle(cornerRadius: 8)
-                                                .fill(LinearGradient.blueGradient)
+                                                .fill(LinearGradient.greenGradient)
                                         )
                                         .overlay {
                                             if soccerMatch.matchCode == 0 {
@@ -325,7 +325,7 @@ struct SoccerMatchInfo: View {
                                         .padding(12)
                                         .background(
                                             RoundedRectangle(cornerRadius: 8)
-                                                .fill(LinearGradient.blueGradient)
+                                                .fill(LinearGradient.greenGradient)
                                         )
                                         .overlay {
                                             if soccerMatch.matchCode != 3 {
@@ -377,7 +377,7 @@ struct SoccerMatchInfo: View {
                                 .padding(12)
                                 .background(
                                     RoundedRectangle(cornerRadius: 8)
-                                        .fill(LinearGradient.limeGradient)
+                                        .fill(LinearGradient.greenGradient)
                                 )
                             }
                             
@@ -407,7 +407,7 @@ struct SoccerMatchInfo: View {
                                 .padding(12)
                                 .background(
                                     RoundedRectangle(cornerRadius: 8)
-                                        .fill(LinearGradient.limeGradient)
+                                        .fill(LinearGradient.greenGradient)
                                 )
                             }
                         }


### PR DESCRIPTION
## 🎟️ 관련 이슈 번호, Jira 번호
closed issue #41 
closed jira #88

## ✨ 변경 사항 및 이유
- gradient 오류 수정
- 경기 캘린더 화면에서 사용하는 응답 모델을 새로운 응답 모델로 바꿔놨었음. 그러나 서버에서 아직 변경된 응답 모델의 반영이 되지 않았기 때문에, 서버 통신 시 오류가 발생함.
- 이에, 응답 모델을 변경함. (추후 백엔드가 새로운 응답 모델로 변경시, 다시 원상복구 필요)

