### PR TITLE
🔧 [FIX] 네트워크 통신 구조 에러 해결

### DIFF
--- a/KickIt/KickIt/Global/Views/CustomDatePicker.swift
+++ b/KickIt/KickIt/Global/Views/CustomDatePicker.swift
@@ -97,8 +97,8 @@ struct CustomDatePicker: View {
         VStack(spacing: 0) {
             if (date.day != -1) {
                 // 해당 날짜에 경기 일정이 있는지에 대한 여부 반환
-                let isSoccerMatch = dummySoccerMatches.contains { match in
-                    return isSameDay(date1: match.matchDate, date2: date.date)
+                let isSoccerMatch = matchDates.contains { match in
+                    return isSameDay(date1: match, date2: date.date)
                 }
                 
                 // 오늘 날짜

--- a/KickIt/KickIt/Network/APIEssentials/CommonResponse.swift
+++ b/KickIt/KickIt/Network/APIEssentials/CommonResponse.swift
@@ -26,6 +26,6 @@ struct CommonResponse<T: Codable>: Codable {
         status = (try? values.decode(Int.self, forKey: .status)) ?? -1
         isSuccess = (try? values.decode(Bool.self, forKey: .isSuccess)) ?? false
         message = (try? values.decode(String.self, forKey: .message)) ?? ""
-        data = (try? values.decode(T.self, forKey: .data)) ?? nil
+        data = (try? values.decodeIfPresent(T.self, forKey: .data)) ?? nil
     }
 }

--- a/KickIt/KickIt/Network/APIManagers/MatchCalendarAPI.swift
+++ b/KickIt/KickIt/Network/APIManagers/MatchCalendarAPI.swift
@@ -19,9 +19,8 @@ class MatchCalendarAPI: BaseAPI {
     }
     
     /// 한달 경기 일정 조회 API
-    // FIXME: [SoccerMatchMonthlyResponse] -> SoccerMatchMonthlyResponse로 수정하기
-    func getYearMonthSoccerMatches(request: SoccerMatchMonthlyRequest) -> AnyPublisher<[SoccerMatchMonthlyResponse], NetworkError> {
-        return Future<[SoccerMatchMonthlyResponse], NetworkError> { [weak self] promise in
+    func getYearMonthSoccerMatches(request: SoccerMatchMonthlyRequest) -> AnyPublisher<SoccerMatchMonthlyResponse, NetworkError> {
+        return Future<SoccerMatchMonthlyResponse, NetworkError> { [weak self] promise in
             guard let self = self else {
                 // 잘못된 요청
                 promise(.failure(.pathErr))
@@ -30,22 +29,26 @@ class MatchCalendarAPI: BaseAPI {
             
             self.AFManager.request(MatchCalendarService.getYearMonthSoccerMatches(request), interceptor: MyRequestInterceptor())
                 .validate()
-                .responseDecodable(of: CommonResponse<[SoccerMatchMonthlyResponse]>.self) { response in
+                .responseDecodable(of: CommonResponse<SoccerMatchMonthlyResponse>.self) { response in
                     switch response.result {
                     // API 호출 성공
                     case .success(let result):
-                        // FIXME: isSuccess 활용하여 로직 수정 필요
-                        switch result.status {
-                        case 200:
-                            return promise(.success(result.data ?? [SoccerMatchMonthlyResponse(matchDates: "")]))
-                        case 401: // TODO: 토큰 오류 interceptor 코드 작동하는지 확인 후, 삭제해도 OK
-                            return promise(.failure(.authFailed))
-                        case 400..<500: // 요청 실패
-                            return promise(.failure(.requestErr(result.message)))
-                        case 500: // 서버 오류
-                            return promise(.failure(.serverErr(result.message)))
-                        default: // 알 수 없는 오류
-                            return promise(.failure(.unknown(result.message)))
+                        // 응답 성공
+                        if result.isSuccess {
+                            promise(.success(result.data ?? SoccerMatchMonthlyResponse(soccerSeason: "", matchDates: [], soccerTeamNames: [])))
+                        }
+                        // 응답 실패
+                        else {
+                            switch result.status {
+                            case 401: // TODO: 토큰 오류 interceptor 코드 작동하는지 확인 후, 삭제해도 OK
+                                return promise(.failure(.authFailed))
+                            case 400..<500: // 요청 실패
+                                return promise(.failure(.requestErr(result.message)))
+                            case 500: // 서버 오류
+                                return promise(.failure(.serverErr(result.message)))
+                            default: // 알 수 없는 오류
+                                return promise(.failure(.unknown(result.message)))
+                            }
                         }
                     // API 호출 실패
                     case .failure(let error):
@@ -70,18 +73,22 @@ class MatchCalendarAPI: BaseAPI {
                     switch response.result {
                     // API 호출 성공
                     case .success(let result):
-                        // FIXME: isSuccess 활용하여 로직 수정 필요
-                        switch result.status {
-                        case 200:
-                            return promise(.success(result.data ?? []))
-                        case 401: // TODO: 토큰 오류 interceptor 코드 작동하는지 확인 후, 삭제해도 OK
-                            return promise(.failure(.authFailed))
-                        case 400..<500: // 요청 실패
-                            return promise(.failure(.requestErr(result.message)))
-                        case 500: // 서버 오류
-                            return promise(.failure(.serverErr(result.message)))
-                        default: // 알 수 없는 오류
-                            return promise(.failure(.unknown(result.message)))
+                        // 응답 성공
+                        if result.isSuccess {
+                            promise(.success(result.data ?? []))
+                        }
+                        // 응답 실패
+                        else {
+                            switch result.status {
+                            case 401: // TODO: 토큰 오류 interceptor 코드 작동하는지 확인 후, 삭제해도 OK
+                                return promise(.failure(.authFailed))
+                            case 400..<500: // 요청 실패
+                                return promise(.failure(.requestErr(result.message)))
+                            case 500: // 서버 오류
+                                return promise(.failure(.serverErr(result.message)))
+                            default: // 알 수 없는 오류
+                                return promise(.failure(.unknown(result.message)))
+                            }
                         }
                     // API 호출 실패
                     case .failure(let error):

--- a/KickIt/KickIt/Network/Bases/MyRequestInterceptor.swift
+++ b/KickIt/KickIt/Network/Bases/MyRequestInterceptor.swift
@@ -12,10 +12,7 @@ final class MyRequestInterceptor: RequestInterceptor {
     // 네트워크 호출 시, api 전처리를 한 뒤 서버로 보냄
     func adapt(_ urlRequest: URLRequest, for session: Session, completion: @escaping (Result<URLRequest, Error>) -> Void) {
         guard urlRequest.url?.absoluteString.hasPrefix(APIConstants.baseURL) == true,
-              let xAuthToken = KeyChain.shared.getJwtToken(),
-              // 회원가입과 로그인 API에는 토큰을 포함하지 않도록 수정
-              urlRequest.url?.absoluteString.contains("/user/signup") == false,
-              urlRequest.url?.absoluteString.contains("/user/login") == false else {
+              let xAuthToken = KeyChain.shared.getJwtToken() else {
             completion(.success(urlRequest))
             return
         }

--- a/KickIt/KickIt/Network/Bases/TargetType.swift
+++ b/KickIt/KickIt/Network/Bases/TargetType.swift
@@ -88,7 +88,7 @@ extension TargetType {
             let params = query.toDictionary()
             // parameter 중 nil값 처리
             let queryParams = params.compactMap { (key, value) -> URLQueryItem? in
-                if let value = value as? String, !value.isEmpty, value != "<null>" {
+                if let value = value as? String, !value.isEmpty {
                     let encoding = value
                     return URLQueryItem(name: key, value: encoding)
                 }
@@ -116,11 +116,15 @@ extension TargetType {
             request.httpBody = try JSONSerialization.data(withJSONObject: bodyParams, options: [])
             
         case .requestBody(let body):
+            var components = URLComponents(string: url.appendingPathComponent(endPoint.encodeURL()!).absoluteString)
+            request.url = components?.url
+            
             let bodyParams = body.toDictionary()
             request.httpBody = try JSONSerialization.data(withJSONObject: bodyParams, options: [])
         
         case .requestPlain:
-            break
+            var components = URLComponents(string: url.appendingPathComponent(endPoint.encodeURL()!).absoluteString)
+            request.url = components?.url
         }
         
         return request

--- a/KickIt/KickIt/Network/Bases/TargetType.swift
+++ b/KickIt/KickIt/Network/Bases/TargetType.swift
@@ -54,15 +54,14 @@ extension TargetType {
     
     /// URL 요청 생성
     func asURLRequest() throws -> URLRequest {
-        // ?를 인코딩할 수 있는 형태로 변경
-        let url = try baseURL.encodeURL()?.asURL()
-        var urlRequest = try URLRequest(url: url!, method: method)
+        let url = try baseURL.asURL()
+        var urlRequest = try URLRequest(url: url, method: method)
         
         // header 설정
         urlRequest = self.makeHeaderForRequest(to: urlRequest)
         
         // parameter 설정
-        return try self.makeParameterForRequest(to: urlRequest, with: url!)
+        return try self.makeParameterForRequest(to: urlRequest, with: url)
     }
     
     /// API 요청 시 header 설정
@@ -89,13 +88,13 @@ extension TargetType {
             let params = query.toDictionary()
             // parameter 중 nil값 처리
             let queryParams = params.compactMap { (key, value) -> URLQueryItem? in
-                if let value = value as? String, !value.isEmpty {
-                    let encoding = value.encodeURL() // 한글 인코딩
+                if let value = value as? String, !value.isEmpty, value != "<null>" {
+                    let encoding = value
                     return URLQueryItem(name: key, value: encoding)
                 }
                 return nil
             }
-            var components = URLComponents(string: url.appendingPathComponent(endPoint).absoluteString)
+            var components = URLComponents(string: url.appendingPathComponent(endPoint.encodeURL()!).absoluteString)
             components?.queryItems = queryParams
             request.url = components?.url
             
@@ -104,12 +103,12 @@ extension TargetType {
             // parameter 중 nil값 처리
             let queryParams = params.compactMap { (key, value) -> URLQueryItem? in
                 if let value = value as? String, !value.isEmpty {
-                    let encoding = value.encodeURL() // 한글 인코딩
+                    let encoding = value
                     return URLQueryItem(name: key, value: encoding)
                 }
                 return nil
             }
-            var components = URLComponents(string: url.appendingPathComponent(endPoint).absoluteString)
+            var components = URLComponents(string: url.appendingPathComponent(endPoint.encodeURL()!).absoluteString)
             components?.queryItems = queryParams
             request.url = components?.url
             

--- a/KickIt/KickIt/Network/Models/Response/SoccerMatchDailyResponse.swift
+++ b/KickIt/KickIt/Network/Models/Response/SoccerMatchDailyResponse.swift
@@ -13,12 +13,12 @@ struct SoccerMatchDailyResponse: Codable {
     let soccerSeason: String // 축구 경기 시즌
     var matchDate: String // 축구 경기 날짜
     var matchTime: String // 축구 경기 시간
-    //var homeTeamEmblemURL: String // 홈팀 엠블럼
-    //var awayTeamEmblemURL: String // 원정팀 엠블럼
+    var homeTeamEmblemURL: String // 홈팀 엠블럼
+    var awayTeamEmblemURL: String // 원정팀 엠블럼
     var homeTeamName: String // 홈팀 이름
     var awayTeamName: String // 원정팀 이름
-    var homeTeamScore: Int? // 홈팀 스코어
-    var awayTeamScore: Int? // 원정팀 스코어
+    var homeTeamScore: Int? = nil // 홈팀 스코어
+    var awayTeamScore: Int? = nil // 원정팀 스코어
     let matchRound: Int // 라운드
     var matchCode: Int // 경기 상태(0: 예정, 1: 경기중, 2: 휴식, 3: 종료, 4: 연기)
     var stadium: String // 축구 경기 장소
@@ -33,6 +33,7 @@ struct SoccerMatchDailyResponse: Codable {
         case matchCode = "status"
         case awayTeamScore = "awayteamScore"
         case id, homeTeamScore, stadium
-        //case homeTeamEmblemURL, awayTeamEmblemURL,
+        case homeTeamEmblemURL = "homeTeamEmblemUrl"
+        case awayTeamEmblemURL = "awayTeamEmblemUrl"
     }
 }

--- a/KickIt/KickIt/Network/Models/Response/SoccerMatchMonthlyResponse.swift
+++ b/KickIt/KickIt/Network/Models/Response/SoccerMatchMonthlyResponse.swift
@@ -9,14 +9,13 @@ import Foundation
 
 /// 한달 경기 일정 조회 Response 모델
 struct SoccerMatchMonthlyResponse: Codable {
-    let matchDates: String // 축구 경기 날짜
-    //let soccerSeason: String // 축구 시즌
-    //let matchDates: [String] // 축구 경기 날짜
-    //let soccerTeamNames: Array<String> // 팀 이름
+    let soccerSeason: String // 축구 시즌
+    let matchDates: [String] // 축구 경기 날짜
+    let soccerTeamNames: [String]? // 팀 이름
     
     enum CodingKeys: String, CodingKey {
-        //case soccerSeason = "soccerSeason"
-        case matchDates = "date"
-        //case soccerTeamNames = "teamNames"
+        case soccerSeason = "soccerSeason"
+        case matchDates = "matchDates"
+        case soccerTeamNames = "soccerTeamNames"
     }
 }

--- a/KickIt/KickIt/Screen/MatchCalendar/ViewModels/MatchCalendarViewModel.swift
+++ b/KickIt/KickIt/Screen/MatchCalendar/ViewModels/MatchCalendarViewModel.swift
@@ -25,26 +25,32 @@ final class MatchCalendarViewModel: MatchCalendarViewModelProtocol {
     @Published var selectedTeamName: String?
     
     /// 사용자가 선택한 경기
-    @Published var selectedSoccerMatch: SoccerMatch? = dummySoccerMatches[1] // FIXME: api연동시 초기값 삭제!
+    @Published var selectedSoccerMatch: SoccerMatch?
     
     private var cancellables = Set<AnyCancellable>()
+    
+    init() {
+        // 한달 경기 날짜 조회 API 호출
+        getYearMonthSoccerMatches(request: SoccerMatchMonthlyRequest(yearMonth: dateToString5(date: Date()), teamName: nil))
+        
+        // 하루 경기 일정 조회 API 연결
+        getDailySoccerMatches(request: SoccerMatchDailyRequest(date: dateToString4(date: Date()), teamName: nil))
+    }
     
     /// 한달 경기 일정(날짜) 조회
     func getYearMonthSoccerMatches(request: SoccerMatchMonthlyRequest) {
         MatchCalendarAPI.shared.getYearMonthSoccerMatches(request: request)
-        // DTO -> Entity로 변경
+            // DTO -> Entity로 변경
             .map { responseDTO in
-                // FIXME: dates, teamNames, season가 있는 버전으로 바꾸기. -> 주석 삭제!
-                let dates = responseDTO.compactMap { stringToDate2(date: $0.matchDates) }
-                //let dates = responseDTO.matchDates.compactMap { stringToDate2(date: $0) }
-                //let teamNames = responseDTO.soccerTeamNames
-                //let season = responseDTO.soccerSeason
+                let dates: [Date] = responseDTO.matchDates.compactMap { stringToDate2(date: $0) }
+                let teamNames: [String] = responseDTO.soccerTeamNames ?? []
+                let season: String = responseDTO.soccerSeason
                 
-                return (dates)
+                return (dates, teamNames, season)
             }
-        // 메인 스레드에서 데이터 처리
+            // 메인 스레드에서 데이터 처리
             .receive(on: DispatchQueue.main)
-        // publisher 결과 구독
+            // publisher 결과 구독
             .sink(receiveCompletion: { completion in
                 switch completion {
                 case .failure(let error):
@@ -53,36 +59,38 @@ final class MatchCalendarViewModel: MatchCalendarViewModelProtocol {
                     break
                 }
             },
-                  // monthlyMatches에 publisher 응답 결과 업데이트
-                  receiveValue: { [weak self] (dates) in
+            // monthlyMatches에 publisher 응답 결과 업데이트
+            receiveValue: { [weak self] (dates, teamNames, season) in
                 self?.matchDates = dates
-                //self?.soccerTeamNames = ["전체"] + teams
-                //self?.soccerSeason = season
+                if !teamNames.isEmpty {
+                    self?.soccerTeamNames = ["전체"] + teamNames
+                }
+                self?.soccerSeason = season
             })
             .store(in: &cancellables)
     }
     
     /// 하루 경기 일정 조회
-    // FIXME: 홈팀, 원정팀 엠블럼 데이터 받아올 수 있게 되면, 추가하기!
     func getDailySoccerMatches(request: SoccerMatchDailyRequest) {
         MatchCalendarAPI.shared.getDailySoccerMatches(request: request)
-        // DTO -> Entity로 변경
+            // DTO -> Entity로 변경
             .map { responseDTO in
-                responseDTO.map { data in
+                let matches = responseDTO.map { data in
                     SoccerMatch(
                         id: data.id,
                         matchDate: stringToDate(date: data.matchDate),
                         matchTime: stringToTime(time: data.matchTime),
                         stadium: data.stadium,
                         matchRound: data.matchRound,
-                        homeTeam: SoccerTeam(teamEmblemURL: "", teamName: data.homeTeamName),
-                        awayTeam: SoccerTeam(teamEmblemURL: "", teamName: data.awayTeamName),
+                        homeTeam: SoccerTeam(teamEmblemURL: data.homeTeamEmblemURL, teamName: data.homeTeamName),
+                        awayTeam: SoccerTeam(teamEmblemURL: data.awayTeamEmblemURL, teamName: data.awayTeamName),
                         matchCode: data.matchCode)
                 }
+                return matches
             }
-        // 메인 스레드에서 데이터 처리
+            // 메인 스레드에서 데이터 처리
             .receive(on: DispatchQueue.main)
-        // publisher 결과 구독
+            // publisher 결과 구독
             .sink(receiveCompletion: { completion in
                 switch completion {
                 case .failure(let error):
@@ -91,18 +99,38 @@ final class MatchCalendarViewModel: MatchCalendarViewModelProtocol {
                     break
                 }
             },
-                  // publisher 결과 구독 성공
-                  receiveValue: { [weak self] matches in
+            // publisher 결과 구독 성공
+            receiveValue: { [weak self] matches in
+                print("날짜 \(matches)")
                 self?.soccerMatches = matches
             })
             .store(in: &cancellables)
     }
     
+    /// 경기 일정 변환 함수(DTO -> Entity)
+    private func matchesToEntity(_ dto: [SoccerMatchDailyResponse]) -> [SoccerMatch] {
+        return dto.compactMap { data in
+            SoccerMatch(
+                id: data.id,
+                matchDate: stringToDate(date: data.matchDate),
+                matchTime: stringToTime(time: data.matchTime),
+                stadium: data.stadium,
+                matchRound: data.matchRound,
+                homeTeam: SoccerTeam(teamEmblemURL: data.homeTeamEmblemURL, teamName: data.homeTeamName),
+                awayTeam: SoccerTeam(teamEmblemURL: data.awayTeamEmblemURL, teamName: data.awayTeamName),
+                matchCode: data.matchCode)
+        }
+    }
+    
     /// 라디오 버튼 클릭 이벤트
     func selectedTeam(_ teamName: String, id: Int) {
         selectedRadioBtnID = id
-        
-        if (selectedTeamName == "전체") {
+        setSelectedTeamName(teamName: teamName)
+    }
+    
+    /// 팀 이름 전환 함수
+    func setSelectedTeamName(teamName: String?) {
+        if (teamName == "전체") {
             selectedTeamName = nil
         }
         else {

--- a/KickIt/KickIt/Screen/MatchCalendar/Views/MatchCalendar.swift
+++ b/KickIt/KickIt/Screen/MatchCalendar/Views/MatchCalendar.swift
@@ -105,19 +105,15 @@ struct MatchCalendar: View {
             }
             .ignoresSafeArea(edges: .top)
         }
-        .onAppear(perform: {
-            // 초기 진입 시, 한달 경기 날짜 조회 API 호출
-            getDayYearMonthSoccerMatches()
-            
-            // 하루 경기 일정 조회 API 연결
-            getDailySoccerMatches()
-        })
         .tint(.gray200)
         .navigationBarBackButtonHidden()
     }
     
     /// 하루 축구 경기 일정 불러오기
     private func getDailySoccerMatches() {
+        // 팀 이름 변환
+        viewModel.setSelectedTeamName(teamName: viewModel.selectedTeamName)
+        
         viewModel.getDailySoccerMatches(
             request: SoccerMatchDailyRequest(
                 date: dateToString4(date: currentDate),
@@ -128,6 +124,9 @@ struct MatchCalendar: View {
     
     /// 한달 축구 경기 일정 불러오기
     private func getDayYearMonthSoccerMatches() {
+        // 팀 이름 변환
+        viewModel.setSelectedTeamName(teamName: viewModel.selectedTeamName)
+        
         viewModel.getYearMonthSoccerMatches(
             request: SoccerMatchMonthlyRequest(
                 yearMonth: dateToString5(date: currentDate),
@@ -185,25 +184,6 @@ struct MatchCalendar: View {
                     .pretendardTextStyle(.Body1Style)
                     .foregroundStyle(.gray500Text)
                     .padding(.top, 48)
-                
-                    // FIXME: api 연결 시, 아래 코드 삭제하기
-                    ForEach(dummySoccerMatches) { match in
-                        NavigationLink {
-                            SoccerMatchInfo(viewModel: viewModel)
-                                .toolbarRole(.editor) // back 텍스트 숨기기
-                                .toolbar(.hidden, for: .tabBar) // 네비게이션 숨기기
-                        } label: {
-                            SoccerMatchRow(soccerMatch: match)
-                                .padding(.horizontal, 16)
-                                .padding(.bottom, 12)
-                        }
-                        .simultaneousGesture(
-                            TapGesture().onEnded {
-                                // 화면 전환 전에 선택한 경기 업데이트
-                                viewModel.selectedMatch(match: match)
-                            }
-                        )
-                    }
             }
         }
     }


### PR DESCRIPTION
## 🎟️ 관련 이슈 번호, Jira 번호
closed issue #58 
closed jira #SF-110

## ✨ 변경 사항 및 이유
- 한달경기조회 api 통신 오류 해결
- 하루경기조회 api 통신 오류 해결
- enpoint 한글 인코딩하도록 수정
- 경기 캘린더에서 더미데이터 대신, api통신 시 받아오는 데이터를 띄우도록 수정
- 경기 캘린더에서 "전체" 라디오버튼 클릭 시, 모든 팀의 한달/하루 경기 조회가 되도록 수정
- MyRequestInterceptor의 jwt 토큰 체크 조건문 삭제
-> 회원가입, 로그인 시점에는 회원탈퇴,로그아웃 시점에서 jwt token을 삭제했기 때문에 jwt token이 없음
-> 이에 따라 회원가입, 로그인 api에는 토큰을 포함하지 않도록 확인하는 조건문 삭제
